### PR TITLE
Use psycopg2 instead of shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,28 +91,21 @@ Here's the raw data:
 
 ```
 
-pip install DSLR
+pip install DSLR psycopg2 # or psycopg2-binary
 
 ````
 
-DSLR requires that the Postgres client binaries (`psql`, `createdb`, `dropdb`)
-are present in your `PATH`. DSLR uses them to interact with Postgres.
+Additionally, the DSLR `export` and `import` snapshot commands require `pg_dump`
+and `pg_restore` to be present in your `PATH`.
 
 ## Configuration
 
 You can tell DSLR which database to take snapshots of in a few ways:
 
-**PG\* environment variables**
-
-If you have the [PG* environment
-variables](https://www.postgresql.org/docs/current/libpq-envars.html) set, DSLR
-will automatically try to use these in a similar way to `psql`.
-
 **DATABASE_URL**
 
 If the `DATABASE_URL` environment variable is set, DSLR will use this to connect
-to your target database. DSLR will prefer this over the PG* environment
-variables.
+to your target database.
 
 ```bash
 export DATABASE_URL=postgres://username:password@host:port/database_name
@@ -120,9 +113,8 @@ export DATABASE_URL=postgres://username:password@host:port/database_name
 
 **dslr.toml**
 
-If you have a `dslr.toml` file in the same directory where you're running
-`dslr`, DSLR will read its settings from it. DSLR will prefer this over the
-environment variables.
+If a `dslr.toml` file exists in the current directory, DSLR will read its
+settings from there. DSLR will prefer this over the environment variable.
 
 ```toml
 url: postgres://username:password@host:port/database_name
@@ -134,8 +126,6 @@ Finally, you can explicitly pass the connection string via the `--url` option.
 This will override any of the above settings.
 
 ## Usage
-
-You're ready to use DSLR!
 
 ```
 $ dslr snapshot my-first-snapshot

--- a/dslr/cli.py
+++ b/dslr/cli.py
@@ -10,7 +10,6 @@ from rich.table import Table
 from .config import settings
 from .console import console, cprint, eprint
 from .operations import (
-    DSLRException,
     SnapshotNotFound,
     create_snapshot,
     delete_snapshot,
@@ -100,7 +99,7 @@ def snapshot(name: str):
     try:
         with console.status("Creating snapshot"):
             create_snapshot(name)
-    except DSLRException as e:
+    except Exception as e:
         eprint("Failed to create snapshot")
         eprint(e, style="white")
         sys.exit(1)
@@ -126,7 +125,7 @@ def restore(name):
     with console.status("Restoring snapshot"):
         try:
             restore_snapshot(snapshot)
-        except DSLRException as e:
+        except Exception as e:
             eprint("Failed to restore snapshot")
             eprint(e, style="white")
             sys.exit(1)
@@ -141,7 +140,7 @@ def list():
     """
     try:
         snapshots = get_snapshots()
-    except DSLRException as e:
+    except Exception as e:
         eprint("Failed to list snapshots")
         eprint(f"{e}", style="white")
         sys.exit(1)
@@ -174,7 +173,7 @@ def delete(name):
 
     try:
         delete_snapshot(snapshot)
-    except DSLRException as e:
+    except Exception as e:
         eprint("Failed to delete snapshot")
         eprint(e, style="white")
         sys.exit(1)
@@ -212,7 +211,7 @@ def rename(old_name, new_name):
 
     try:
         rename_snapshot(old_snapshot, new_name)
-    except DSLRException as e:
+    except Exception as e:
         eprint("Failed to rename snapshot")
         eprint(e, style="white")
         sys.exit(1)
@@ -235,7 +234,7 @@ def export(name):
     try:
         with console.status("Exporting snapshot"):
             export_path = export_snapshot(snapshot)
-    except DSLRException as e:
+    except Exception as e:
         eprint("Failed to export snapshot")
         eprint(e, style="white")
         sys.exit(1)
@@ -269,7 +268,7 @@ def import_(filename, name):
     try:
         with console.status("Importing snapshot"):
             import_snapshot(filename, name)
-    except DSLRException as e:
+    except Exception as e:
         eprint("Failed to import snapshot")
         eprint(e, style="white")
         sys.exit(1)

--- a/dslr/operations.py
+++ b/dslr/operations.py
@@ -7,11 +7,6 @@ from psycopg2 import sql
 from .config import settings
 from .runner import exec_shell, exec_sql
 
-
-class DSLRException(Exception):
-    pass
-
-
 ################################################################################
 # Database operations
 ################################################################################
@@ -166,10 +161,7 @@ def export_snapshot(snapshot: Snapshot) -> str:
     Exports the given snapshot to a file
     """
     export_path = f"{snapshot.name}_{snapshot.created_at:%Y%m%d-%H%M%S}.dump"
-    result = exec_shell("pg_dump", "-Fc", "-d", snapshot.dbname, "-f", export_path)
-
-    if result.returncode != 0:
-        raise DSLRException(result.stderr)
+    exec_shell("pg_dump", "-Fc", "-d", snapshot.dbname, "-f", export_path)
 
     return export_path
 
@@ -181,9 +173,4 @@ def import_snapshot(import_path: str, snapshot_name: str):
     dbname = generate_snapshot_db_name(snapshot_name)
     create_database(dbname=dbname)
 
-    result = exec_shell(
-        "pg_restore", "-d", dbname, "--no-acl", "--no-owner", import_path
-    )
-
-    if result.returncode != 0:
-        raise DSLRException(result.stderr)
+    exec_shell("pg_restore", "-d", dbname, "--no-acl", "--no-owner", import_path)

--- a/dslr/pg_client.py
+++ b/dslr/pg_client.py
@@ -1,0 +1,23 @@
+from typing import Any, List, Tuple
+
+import psycopg2
+
+
+class PGClient:
+    """
+    Thin wrapper around psycopg2
+    """
+
+    def __init__(self, host, port, user, password, dbname):
+        self.conn = psycopg2.connect(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            dbname=dbname,
+        )
+        self.cur = self.conn.cursor()
+
+    def execute(self, sql, data) -> List[Tuple[Any, ...]]:
+        self.cur.execute(sql, data)
+        return self.cur.fetchall()

--- a/dslr/runner.py
+++ b/dslr/runner.py
@@ -63,7 +63,7 @@ def exec_sql(
 
     if not pg_client:
         # We always want to connect to the `postgres` and not the target
-        # database because all of our operations don't need to query the target
+        # database because none of our operations need to query the target
         # database.
         pg_client = PGClient(
             host=settings.db.host,

--- a/dslr/runner.py
+++ b/dslr/runner.py
@@ -1,7 +1,9 @@
 import os
 import subprocess
 from collections import namedtuple
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
+
+from psycopg2 import sql
 
 from dslr.pg_client import PGClient
 
@@ -50,7 +52,9 @@ def exec_shell(*cmd: str) -> Result:
 pg_client: Optional[PGClient] = None
 
 
-def exec_sql(sql: str, data: Optional[List[Any]] = None) -> List[Tuple[Any, ...]]:
+def exec_sql(
+    sql: Union[sql.SQL, str], data: Optional[List[Any]] = None
+) -> Optional[List[Tuple[Any, ...]]]:
     """
     Executes a SQL query.
     """

--- a/dslr/runner.py
+++ b/dslr/runner.py
@@ -1,6 +1,9 @@
 import os
 import subprocess
 from collections import namedtuple
+from typing import Any, Dict, List, Optional, Tuple
+
+from dslr.pg_client import PGClient
 
 from .config import settings
 from .console import console
@@ -35,8 +38,31 @@ def exec(*cmd: str) -> Result:
             console.log("STDOUT:\n", stdout.decode("utf-8"), "\n")
             console.log("STDERR:\n", stderr.decode("utf-8"), "\n")
 
+        # TODO: Make this raise an exception instead
         return Result(
             returncode=p.returncode,
             stdout=stdout.decode("utf-8"),
             stderr=stderr.decode("utf-8"),
         )
+
+
+# Singleton instance of PGClient
+pg_client: Optional[PGClient] = None
+
+
+def exec_sql(sql: str, data: Optional[Dict[Any, Any]] = None) -> List[Tuple[Any, ...]]:
+    """
+    Executes a SQL query.
+    """
+    global pg_client
+
+    if not pg_client:
+        pg_client = PGClient(
+            host=settings.db.host,
+            port=settings.db.port,
+            user=settings.db.username,
+            password=settings.db.password,
+            dbname="postgres",
+        )
+
+    return pg_client.execute(sql, data)

--- a/dslr/runner.py
+++ b/dslr/runner.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 from collections import namedtuple
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 from dslr.pg_client import PGClient
 
@@ -11,7 +11,7 @@ from .console import console
 Result = namedtuple("Result", ["returncode", "stdout", "stderr"])
 
 
-def exec(*cmd: str) -> Result:
+def exec_shell(*cmd: str) -> Result:
     """
     Executes a command.
     """
@@ -50,13 +50,16 @@ def exec(*cmd: str) -> Result:
 pg_client: Optional[PGClient] = None
 
 
-def exec_sql(sql: str, data: Optional[Dict[Any, Any]] = None) -> List[Tuple[Any, ...]]:
+def exec_sql(sql: str, data: Optional[List[Any]] = None) -> List[Tuple[Any, ...]]:
     """
     Executes a SQL query.
     """
     global pg_client
 
     if not pg_client:
+        # We always want to connect to the `postgres` and not the target
+        # database because all of our operations don't need to query the target
+        # database.
         pg_client = PGClient(
             host=settings.db.host,
             port=settings.db.port,

--- a/dslr/runner.py
+++ b/dslr/runner.py
@@ -10,7 +10,7 @@ from dslr.pg_client import PGClient
 from .config import settings
 from .console import console
 
-Result = namedtuple("Result", ["returncode", "stdout", "stderr"])
+Result = namedtuple("Result", ["stdout", "stderr"])
 
 
 def exec_shell(*cmd: str) -> Result:
@@ -40,9 +40,10 @@ def exec_shell(*cmd: str) -> Result:
             console.log("STDOUT:\n", stdout.decode("utf-8"), "\n")
             console.log("STDERR:\n", stderr.decode("utf-8"), "\n")
 
-        # TODO: Make this raise an exception instead
+        if p.returncode != 0:
+            raise RuntimeError(f"Command failed: {cmd}")
+
         return Result(
-            returncode=p.returncode,
             stdout=stdout.decode("utf-8"),
             stderr=stderr.decode("utf-8"),
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Tuple
 from unittest import TestCase, mock
 
 from click.testing import CliRunner
@@ -8,11 +8,11 @@ from click.testing import CliRunner
 from dslr import cli, operations, runner
 
 
-def stub_exec_shell(*cmd: str):
+def stub_exec_shell(*args, **kwargs):
     return runner.Result(returncode=0, stdout="", stderr="")
 
 
-def stub_exec_sql(sql: str, data: Optional[List[Any]] = None) -> List[Tuple[Any, ...]]:
+def stub_exec_sql(*args, **kwargs) -> List[Tuple[Any, ...]]:
     fake_snapshot_1 = operations.generate_snapshot_db_name(
         "existing-snapshot-1",
         created_at=datetime(2020, 1, 1, 0, 0, 0, 0),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 from dslr import cli, operations, runner
 
 
-def stub_exec_shell(*args, **kwargs):
+def stub_exec_shell(*args, **kwargs) -> runner.Result:
     return runner.Result(stdout="", stderr="")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,17 +166,15 @@ class CliTest(TestCase):
         )
 
 
-@mock.patch("dslr.operations.exec_shell", new=stub_exec_shell)
-@mock.patch("dslr.operations.exec_sql", new=stub_exec_sql)
+@mock.patch("dslr.cli.get_snapshots")
 class ConfigTest(TestCase):
     @mock.patch.dict(
         os.environ, {"DATABASE_URL": "postgres://envvar:pw@test:5432/my_db"}
     )
     @mock.patch("dslr.cli.settings")
-    @mock.patch("dslr.operations.settings")
-    def test_database_url(self, mock_operations_settings, mock_cli_settings):
+    def test_database_url(self, mock_cli_settings, mock_get_snapshots):
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ["snapshot", "my-snapshot"])
+        result = runner.invoke(cli.cli, ["list"])
 
         self.assertEqual(result.exit_code, 0)
 
@@ -186,14 +184,13 @@ class ConfigTest(TestCase):
         )
 
     @mock.patch("dslr.cli.settings")
-    @mock.patch("dslr.operations.settings")
-    def test_toml(self, mock_operations_settings, mock_cli_settings):
+    def test_toml(self, mock_cli_settings, mock_get_snapshots):
         with mock.patch(
             "builtins.open",
             mock.mock_open(read_data=b"url = 'postgres://toml:pw@test:5432/my_db'"),
         ):
             runner = CliRunner()
-            result = runner.invoke(cli.cli, ["snapshot", "my-snapshot"])
+            result = runner.invoke(cli.cli, ["list"])
 
         self.assertEqual(result.exit_code, 0)
 
@@ -203,12 +200,11 @@ class ConfigTest(TestCase):
         )
 
     @mock.patch("dslr.cli.settings")
-    @mock.patch("dslr.operations.settings")
-    def test_db_option(self, mock_operations_settings, mock_cli_settings):
+    def test_db_option(self, mock_cli_settings, mock_get_snapshots):
         runner = CliRunner()
         result = runner.invoke(
             cli.cli,
-            ["--url", "postgres://cli:pw@test:5432/my_db", "snapshot", "my-snapshot"],
+            ["--url", "postgres://cli:pw@test:5432/my_db", "list"],
         )
 
         self.assertEqual(result.exit_code, 0)
@@ -219,13 +215,10 @@ class ConfigTest(TestCase):
         )
 
     @mock.patch("dslr.cli.settings")
-    @mock.patch("dslr.operations.settings")
-    def test_settings_preference_order(
-        self, mock_operations_settings, mock_cli_settings
-    ):
+    def test_settings_preference_order(self, mock_cli_settings, mock_get_snapshots):
         # No options passed (e.g. PG environment variables are used)
         runner = CliRunner()
-        result = runner.invoke(cli.cli, ["snapshot", "my-snapshot"])
+        result = runner.invoke(cli.cli, ["list"])
         self.assertEqual(result.exit_code, 0)
 
         # DATABASE_URL environment variable is used
@@ -233,7 +226,7 @@ class ConfigTest(TestCase):
             os.environ, {"DATABASE_URL": "postgres://envvar:pw@test:5432/my_db"}
         ):
             runner = CliRunner()
-            result = runner.invoke(cli.cli, ["snapshot", "my-snapshot"])
+            result = runner.invoke(cli.cli, ["list"])
             self.assertEqual(result.exit_code, 0)
 
             # TOML file is used
@@ -242,19 +235,14 @@ class ConfigTest(TestCase):
                 mock.mock_open(read_data=b"url = 'postgres://toml:pw@test:5432/my_db'"),
             ):
                 runner = CliRunner()
-                result = runner.invoke(cli.cli, ["snapshot", "my-snapshot"])
+                result = runner.invoke(cli.cli, ["list"])
                 self.assertEqual(result.exit_code, 0)
 
                 # --url option is used
                 runner = CliRunner()
                 result = runner.invoke(
                     cli.cli,
-                    [
-                        "--url",
-                        "postgres://cli:pw@test:5432/my_db",
-                        "snapshot",
-                        "my-snapshot",
-                    ],
+                    ["--url", "postgres://cli:pw@test:5432/my_db", "list"],
                 )
                 self.assertEqual(result.exit_code, 0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ from dslr import cli, operations, runner
 
 
 def stub_exec_shell(*args, **kwargs):
-    return runner.Result(returncode=0, stdout="", stderr="")
+    return runner.Result(stdout="", stderr="")
 
 
 def stub_exec_sql(*args, **kwargs) -> List[Tuple[Any, ...]]:

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ python =
     3.10: py310, flake8, black, isort
 
 [testenv]
+deps = psycopg2-binary
 commands =
     python -m unittest
 


### PR DESCRIPTION
Replace shell commands with direct calls to the database via psycopg2.

This is so that you don't have to install the postgres client binaries to use DSLR.

You'd still need to install it of you want to use `export` and `import` though as those rely on `pg_dump` and `pg_restore`.