### PR TITLE
Add -y flag for overwrite confirmation

### DIFF
--- a/dslr/cli.py
+++ b/dslr/cli.py
@@ -75,7 +75,14 @@ def cli(url, debug):
 
 @cli.command()
 @click.argument("name", shell_complete=complete_snapshot_names)
-def snapshot(name: str):
+@click.option(
+    "-y",
+    "--yes",
+    "overwrite_confirmed",
+    is_flag=True,
+    help="Overwrite existing snapshot without confirmation.",
+)
+def snapshot(name: str, overwrite_confirmed: bool):
     """
     Takes a snapshot of the database
     """
@@ -84,12 +91,13 @@ def snapshot(name: str):
     try:
         snapshot = find_snapshot(name)
 
-        click.confirm(
-            click.style(
-                f"Snapshot {snapshot.name} already exists. Overwrite?", fg="yellow"
-            ),
-            abort=True,
-        )
+        if not overwrite_confirmed:
+            click.confirm(
+                click.style(
+                    f"Snapshot {snapshot.name} already exists. Overwrite?", fg="yellow"
+                ),
+                abort=True,
+            )
 
         delete_snapshot(snapshot)
         new = False
@@ -184,7 +192,14 @@ def delete(name):
 @cli.command()
 @click.argument("old_name", shell_complete=complete_snapshot_names)
 @click.argument("new_name", shell_complete=complete_snapshot_names)
-def rename(old_name, new_name):
+@click.option(
+    "-y",
+    "--yes",
+    "overwrite_confirmed",
+    is_flag=True,
+    help="Overwrite existing snapshot without confirmation.",
+)
+def rename(old_name: str, new_name: str, overwrite_confirmed: bool):
     """
     Renames a snapshot
     """
@@ -197,13 +212,14 @@ def rename(old_name, new_name):
     try:
         existing_snapshot = find_snapshot(new_name)
 
-        click.confirm(
-            click.style(
-                f"Snapshot {existing_snapshot.name} already exists. Overwrite?",
-                fg="yellow",
-            ),
-            abort=True,
-        )
+        if not overwrite_confirmed:
+            click.confirm(
+                click.style(
+                    f"Snapshot {existing_snapshot.name} already exists. Overwrite?",
+                    fg="yellow",
+                ),
+                abort=True,
+            )
 
         delete_snapshot(existing_snapshot)
     except SnapshotNotFound:
@@ -245,7 +261,14 @@ def export(name):
 @cli.command("import")
 @click.argument("filename", type=click.Path(exists=True))
 @click.argument("name", shell_complete=complete_snapshot_names)
-def import_(filename, name):
+@click.option(
+    "-y",
+    "--yes",
+    "overwrite_confirmed",
+    is_flag=True,
+    help="Overwrite existing snapshot without confirmation.",
+)
+def import_(filename: str, name: str, overwrite_confirmed):
     """
     Imports a snapshot from a file
     """
@@ -254,12 +277,13 @@ def import_(filename, name):
     try:
         snapshot = find_snapshot(name)
 
-        click.confirm(
-            click.style(
-                f"Snapshot {snapshot.name} already exists. Overwrite?", fg="yellow"
-            ),
-            abort=True,
-        )
+        if not overwrite_confirmed:
+            click.confirm(
+                click.style(
+                    f"Snapshot {snapshot.name} already exists. Overwrite?", fg="yellow"
+                ),
+                abort=True,
+            )
 
         delete_snapshot(snapshot)
     except SnapshotNotFound:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,20 @@ class CliTest(TestCase):
         )
         self.assertIn("Updated snapshot existing-snapshot-1", result.output)
 
+    def test_snapshot_overwrite_with_yes(self):
+        # stub_exec sets up a fake snapshot called "existing-snapshot-1"
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli,
+            ["snapshot", "existing-snapshot-1", "-y"],
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn(
+            "Snapshot existing-snapshot-1 already exists. Overwrite?", result.output
+        )
+        self.assertIn("Updated snapshot existing-snapshot-1", result.output)
+
     def test_restore(self):
         runner = CliRunner()
         result = runner.invoke(cli.cli, ["restore", "existing-snapshot-1"])
@@ -118,6 +132,20 @@ class CliTest(TestCase):
             "Renamed snapshot existing-snapshot-1 to existing-snapshot-2", result.output
         )
 
+    def test_rename_overwrite_with_yes(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli, ["rename", "existing-snapshot-1", "existing-snapshot-2", "-y"]
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn(
+            "Snapshot existing-snapshot-2 already exists. Overwrite?", result.output
+        )
+        self.assertIn(
+            "Renamed snapshot existing-snapshot-1 to existing-snapshot-2", result.output
+        )
+
     def test_export(self):
         runner = CliRunner()
         result = runner.invoke(cli.cli, ["export", "existing-snapshot-1"])
@@ -158,6 +186,21 @@ class CliTest(TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertIn(
+            "Snapshot existing-snapshot-1 already exists. Overwrite?", result.output
+        )
+        self.assertIn(
+            "Imported snapshot existing-snapshot-1 from pyproject.toml",
+            result.output,
+        )
+
+    def test_import_overwrite_with_yes(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli.cli, ["import", "pyproject.toml", "existing-snapshot-1", "-y"]
+        )
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn(
             "Snapshot existing-snapshot-1 already exists. Overwrite?", result.output
         )
         self.assertIn(


### PR DESCRIPTION
This PR adds a `-y` or `--yes` flag to the `snapshot`, `rename`, and `import` commands which causes it to bypass the "Are you sure you want to overwrite" confirmation prompt.

Closes #3.