### PR TITLE
Add pyright type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,11 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: poetry run npx pyright@1.1.266
+        language: node
+        pass_filenames: false
+        types: [python]

--- a/dslr/operations.py
+++ b/dslr/operations.py
@@ -81,6 +81,9 @@ def get_snapshots() -> List[Snapshot]:
     # Find the snapshot databases
     result = exec_sql("SELECT datname FROM pg_database WHERE datname LIKE 'dslr_%'")
 
+    if not result:
+        raise RuntimeError("Did not get results from database.")
+
     snapshot_dbnames = sorted([row[0] for row in result])
 
     # Parse the name into a Snapshot

--- a/dslr/pg_client.py
+++ b/dslr/pg_client.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Optional, Tuple
 
 import psycopg2
+import psycopg2.extensions
 
 from dslr.console import console
 

--- a/dslr/runner.py
+++ b/dslr/runner.py
@@ -54,7 +54,7 @@ pg_client: Optional[PGClient] = None
 
 
 def exec_sql(
-    sql: Union[sql.SQL, str], data: Optional[List[Any]] = None
+    sql: Union[sql.Composed, str], data: Optional[List[Any]] = None
 ) -> Optional[List[Tuple[Any, ...]]]:
     """
     Executes a SQL query.

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     flake8
     black
     isort
+    pyright
     py37
     py38
     py39
@@ -14,7 +15,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, flake8, black, isort
+    3.10: py310, flake8, black, isort, pyright
 
 [testenv]
 deps = psycopg2-binary
@@ -28,6 +29,10 @@ commands = flake8
 [testenv:black]
 deps = black >=22.6.0, <23.0.0
 commands = black --check ./
+
+[testenv:pyright]
+deps = pyright == 1.1.266
+commands = pyright
 
 [testenv:isort]
 deps = isort >= 5.10.1, <6.0.0


### PR DESCRIPTION
Adds configuration to run pyright on pre-commit and inside tox.

pre-commit use `npx pyright` and tox uses the PyPI pyright.