### PR TITLE
Abort if database name is empty

### DIFF
--- a/dslr/cli.py
+++ b/dslr/cli.py
@@ -73,6 +73,12 @@ def cli(url, debug):
     settings.initialize(**config)
 
 
+def check_database_name():
+    if not settings.db.name:
+        eprint("Database name cannot be empty", style="red")
+        sys.exit(1)
+
+
 @cli.command()
 @click.argument("name", shell_complete=complete_snapshot_names)
 @click.option(
@@ -87,6 +93,7 @@ def snapshot(name: str, overwrite_confirmed: bool):
     Takes a snapshot of the database
     """
     new = True
+    check_database_name()
 
     try:
         snapshot = find_snapshot(name)
@@ -124,6 +131,8 @@ def restore(name):
     """
     Restores the database from a snapshot
     """
+    check_database_name()
+
     try:
         snapshot = find_snapshot(name)
     except SnapshotNotFound:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,6 +68,14 @@ class CliTest(TestCase):
         )
         self.assertIn("Updated snapshot existing-snapshot-1", result.output)
 
+    @mock.patch.dict(os.environ, {"DATABASE_URL": ""})
+    def test_snapshot_with_missing_database_url(self):
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, ["snapshot", "my-snapshot"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Database name cannot be empty", result.output)
+
     def test_restore(self):
         runner = CliRunner()
         result = runner.invoke(cli.cli, ["restore", "existing-snapshot-1"])
@@ -83,6 +91,14 @@ class CliTest(TestCase):
 
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Snapshot not-found does not exist", result.output)
+
+    @mock.patch.dict(os.environ, {"DATABASE_URL": ""})
+    def test_restore_with_missing_database_url(self):
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, ["restore", "existing-snapshot-1"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Database name cannot be empty", result.output)
 
     def test_list(self):
         runner = CliRunner()


### PR DESCRIPTION
Database name is empty if database url is not defined.
Fixes #14